### PR TITLE
Terminal profile customization: warm/cool powerline + SSH auto-switch

### DIFF
--- a/terminal-profiles/README.md
+++ b/terminal-profiles/README.md
@@ -1,0 +1,65 @@
+# Terminal Profile Customization
+
+Visually distinct terminal prompts for multi-machine workflows. At a glance:
+
+- Mac Mini = warm tones (peach, maroon, flamingo, mauve, pink)
+- ROCm AIBox = cool tones (blue, teal, yellow, green)
+
+Both use Catppuccin Mocha palette with Starship powerline segments.
+
+## What changed
+
+### Starship prompts
+
+Both machines now run powerline-style Starship prompts with OS icon, username, hostname, directory, git, language, and duration segments. The color temperature is the differentiator:
+
+| Segment    | Mac Mini (warm)     | AIBox (cool)        |
+|------------|---------------------|---------------------|
+| OS/user    | peach `#fab387`     | blue `#89b4fa`      |
+| hostname   | maroon `#eba0ac`    | teal `#94e2d5`      |
+| directory  | flamingo `#f2cdcd`  | yellow `#f9e2af`    |
+| git        | mauve `#cba6f7`     | green `#a6e3a1`     |
+| languages  | pink `#f5c2e7`      | blue `#89b4fa`      |
+| cursor     | peach `#fab387`     | green `#a6e3a1`     |
+
+### Terminal.app profiles
+
+- `catppuccin-mocha` — default local profile, Mocha base background `#1e1e2e`
+- `rocm-ssh` — SSH profile, Macchiato base background `#24273a` (blue-shifted)
+
+### SSH wrapper (in .zshrc)
+
+A `ssh()` function wraps the real ssh command. When connecting to `rocm-aibox`:
+1. Switches Terminal.app to the `rocm-ssh` profile
+2. Sets window title to "SSH: rocm-aibox"
+3. On disconnect, reverts to `catppuccin-mocha` and clears the title
+
+### Secrets cleanup
+
+- Hardcoded GitHub PAT removed from Mac Mini .zshrc
+- `.zshrc` now sources `~/.secrets` for any sensitive env vars
+- Dynamic token via `$(gh auth token)` handles GitHub auth
+- AIBox has similar hardcoded keys that need the same treatment
+
+## Deploy
+
+```sh
+# Mac Mini
+cp terminal-profiles/starship-mac-mini-warm.toml ~/.config/starship.toml
+
+# AIBox (via SSH)
+scp terminal-profiles/starship-aibox-cool.toml bryanchasko@rocm-aibox.local:~/.config/starship.toml
+```
+
+## Manual step: create ~/.secrets
+
+```sh
+cat > ~/.secrets << 'EOF'
+# ~/.secrets — shell environment overrides
+# Sourced by ~/.zshrc. Never commit this file.
+# Add environment overrides below.
+EOF
+chmod 600 ~/.secrets
+```
+
+Rotate any tokens that were previously hardcoded in shell configs.

--- a/terminal-profiles/starship-aibox-cool.toml
+++ b/terminal-profiles/starship-aibox-cool.toml
@@ -1,0 +1,129 @@
+# Starship Prompt — ROCm AIBox (Cool Powerline)
+# Theme: Catppuccin Mocha — cool accents (blue/teal/green)
+# Deploy: cp to ~/.config/starship.toml on rocm-aibox
+# Visual pair: Mac Mini uses warm peach/maroon/mauve/pink
+
+format = """
+[](fg:#89B4FA)\
+$os\
+$username\
+[](bg:#94E2D5 fg:#89B4FA)\
+$hostname\
+[](bg:#F9E2AF fg:#94E2D5)\
+$directory\
+[](bg:#A6E3A1 fg:#F9E2AF)\
+$git_branch\
+$git_status\
+[](bg:#89B4FA fg:#A6E3A1)\
+$python\
+$rust\
+$nodejs\
+$docker_context\
+[](fg:#89B4FA)\
+$fill\
+$cmd_duration\
+$line_break\
+$character"""
+
+palette = "catppuccin_mocha"
+
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"
+
+[os]
+disabled = false
+style = "bg:#89B4FA fg:#1E1E2E"
+
+[os.symbols]
+Ubuntu = " "
+
+[username]
+show_always = true
+style_user = "bg:#89B4FA fg:#1E1E2E bold"
+style_root = "bg:#F38BA8 fg:#1E1E2E bold"
+format = '[ $user]($style)'
+
+[hostname]
+ssh_only = false
+style = "bg:#94E2D5 fg:#1E1E2E bold"
+format = '[ $hostname ]($style)'
+
+[directory]
+style = "bg:#F9E2AF fg:#1E1E2E bold"
+format = '[ $path ]($style)'
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Code" = " "
+
+[git_branch]
+symbol = ""
+style = "bg:#A6E3A1 fg:#1E1E2E"
+format = '[ $symbol $branch ]($style)'
+
+[git_status]
+style = "bg:#A6E3A1 fg:#1E1E2E"
+format = '[$all_status$ahead_behind ]($style)'
+
+[python]
+symbol = ""
+style = "bg:#89B4FA fg:#1E1E2E"
+format = '[ $symbol ($version) ]($style)'
+
+[rust]
+symbol = ""
+style = "bg:#89B4FA fg:#1E1E2E"
+format = '[ $symbol ($version) ]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:#89B4FA fg:#1E1E2E"
+format = '[ $symbol ($version) ]($style)'
+
+[docker_context]
+symbol = ""
+style = "bg:#89B4FA fg:#1E1E2E"
+format = '[ $symbol $context ]($style)'
+
+[fill]
+symbol = " "
+
+[cmd_duration]
+min_time = 2_000
+style = "fg:#F9E2AF"
+format = '[ $duration]($style)'
+
+[character]
+success_symbol = "[❯](bold #A6E3A1)"
+error_symbol = "[❯](bold #F38BA8)"
+
+[line_break]
+disabled = false

--- a/terminal-profiles/starship-mac-mini-warm.toml
+++ b/terminal-profiles/starship-mac-mini-warm.toml
@@ -1,0 +1,129 @@
+# Starship Prompt — Mac Mini (Warm Powerline)
+# Theme: Catppuccin Mocha — warm accents (peach/maroon/mauve/pink)
+# Deploy: cp to ~/.config/starship.toml on Mac Mini
+# Visual pair: AIBox uses cool blues/teals/greens
+
+format = """
+[](fg:#fab387)\
+$os\
+$username\
+[](bg:#eba0ac fg:#fab387)\
+$hostname\
+[](bg:#f2cdcd fg:#eba0ac)\
+$directory\
+[](bg:#cba6f7 fg:#f2cdcd)\
+$git_branch\
+$git_status\
+[](bg:#f5c2e7 fg:#cba6f7)\
+$python\
+$rust\
+$nodejs\
+$docker_context\
+[](fg:#f5c2e7)\
+$fill\
+$cmd_duration\
+$line_break\
+$character"""
+
+palette = "catppuccin_mocha"
+
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"
+
+[os]
+disabled = false
+style = "bg:#fab387 fg:#1E1E2E"
+
+[os.symbols]
+Macos = " "
+
+[username]
+show_always = true
+style_user = "bg:#fab387 fg:#1E1E2E bold"
+style_root = "bg:#F38BA8 fg:#1E1E2E bold"
+format = '[ $user]($style)'
+
+[hostname]
+ssh_only = false
+style = "bg:#eba0ac fg:#1E1E2E bold"
+format = '[ $hostname ]($style)'
+
+[directory]
+style = "bg:#f2cdcd fg:#1E1E2E bold"
+format = '[ $path ]($style)'
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Code" = " "
+
+[git_branch]
+symbol = ""
+style = "bg:#cba6f7 fg:#1E1E2E"
+format = '[ $symbol $branch ]($style)'
+
+[git_status]
+style = "bg:#cba6f7 fg:#1E1E2E"
+format = '[$all_status$ahead_behind ]($style)'
+
+[python]
+symbol = ""
+style = "bg:#f5c2e7 fg:#1E1E2E"
+format = '[ $symbol ($version) ]($style)'
+
+[rust]
+symbol = ""
+style = "bg:#f5c2e7 fg:#1E1E2E"
+format = '[ $symbol ($version) ]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:#f5c2e7 fg:#1E1E2E"
+format = '[ $symbol ($version) ]($style)'
+
+[docker_context]
+symbol = ""
+style = "bg:#f5c2e7 fg:#1E1E2E"
+format = '[ $symbol $context ]($style)'
+
+[fill]
+symbol = " "
+
+[cmd_duration]
+min_time = 2_000
+style = "fg:#fab387"
+format = '[ $duration]($style)'
+
+[character]
+success_symbol = "[❯](bold #fab387)"
+error_symbol = "[❯](bold #F38BA8)"
+
+[line_break]
+disabled = false


### PR DESCRIPTION
Adds visually distinct terminal configurations for multi-machine workflows.

## Changes

- `terminal-profiles/starship-mac-mini-warm.toml` — warm powerline (peach/maroon/flamingo/mauve/pink) with Apple icon
- `terminal-profiles/starship-aibox-cool.toml` — cool powerline (blue/teal/yellow/green) with Ubuntu icon
- `terminal-profiles/README.md` — deployment docs, color mapping table, SSH wrapper explanation

## Context

Both machines were running near-identical Catppuccin Mocha prompts. Now the color temperature immediately tells you which machine you're on. The Mac Mini .zshrc also got an SSH wrapper that auto-switches Terminal.app profiles when connecting to the AIBox.

## Still needed

- [ ] Create `~/.secrets` on Mac Mini (manual, see README)
- [ ] Rotate the GitHub PAT that was hardcoded in .zshrc
- [ ] Clean up hardcoded API keys on AIBox .zshrc/.bashrc