### PR TITLE
feat: haunting workload profiles — 6 Ghostty profiles mapped to the haunting

### DIFF
--- a/ghostty-profiles/aws.conf
+++ b/ghostty-profiles/aws.conf
@@ -1,0 +1,28 @@
+# Ghostty profile: aws
+# Workload: stratia — AWS, Bedrock, CDK, infrastructure
+# Inherits base config, overrides colors only
+config-file = ~/.config/ghostty/config
+
+background = "#1a1200"
+foreground = "#ffd080"
+cursor-color = "#ff9900"
+selection-background = "#3a2800"
+selection-foreground = "#ffd080"
+
+# Amber/AWS palette
+palette = 0=#1a1200
+palette = 1=#f7768e
+palette = 2=#9ece6a
+palette = 3=#ff9900
+palette = 4=#7aa2f7
+palette = 5=#bb9af7
+palette = 6=#7dcfff
+palette = 7=#ffd080
+palette = 8=#3a2800
+palette = 9=#f7768e
+palette = 10=#9ece6a
+palette = 11=#ff9900
+palette = 12=#7aa2f7
+palette = 13=#bb9af7
+palette = 14=#7dcfff
+palette = 15=#ffd080

--- a/ghostty-profiles/chrome-ext.conf
+++ b/ghostty-profiles/chrome-ext.conf
@@ -1,0 +1,28 @@
+# Ghostty profile: chrome-ext
+# Workload: ellow — Chrome MV3, Puppeteer, Jest, web extension dev
+# Inherits base config, overrides colors only
+config-file = ~/.config/ghostty/config
+
+background = "#001a1a"
+foreground = "#c0f0f0"
+cursor-color = "#7dcfff"
+selection-background = "#003333"
+selection-foreground = "#c0f0f0"
+
+# Teal/cyan web-dev palette
+palette = 0=#001a1a
+palette = 1=#f7768e
+palette = 2=#9ece6a
+palette = 3=#e0af68
+palette = 4=#7aa2f7
+palette = 5=#bb9af7
+palette = 6=#7dcfff
+palette = 7=#c0f0f0
+palette = 8=#003333
+palette = 9=#f7768e
+palette = 10=#9ece6a
+palette = 11=#e0af68
+palette = 12=#7aa2f7
+palette = 13=#bb9af7
+palette = 14=#7dcfff
+palette = 15=#c0f0f0

--- a/ghostty-profiles/inference.conf
+++ b/ghostty-profiles/inference.conf
@@ -1,0 +1,28 @@
+# Ghostty profile: inference
+# Workload: myrren — Ollama, Qdrant, local model orchestration
+# Inherits base config, overrides colors only
+config-file = ~/.config/ghostty/config
+
+background = "#0d0014"
+foreground = "#e0d0ff"
+cursor-color = "#bb9af7"
+selection-background = "#2a0050"
+selection-foreground = "#e0d0ff"
+
+# Violet/neural palette
+palette = 0=#0d0014
+palette = 1=#f7768e
+palette = 2=#9ece6a
+palette = 3=#e0af68
+palette = 4=#7aa2f7
+palette = 5=#bb9af7
+palette = 6=#cba6f7
+palette = 7=#c0b0e0
+palette = 8=#2a0050
+palette = 9=#f7768e
+palette = 10=#9ece6a
+palette = 11=#e0af68
+palette = 12=#7aa2f7
+palette = 13=#bb9af7
+palette = 14=#cba6f7
+palette = 15=#e0d0ff

--- a/ghostty-profiles/mcp-forge.conf
+++ b/ghostty-profiles/mcp-forge.conf
@@ -1,0 +1,28 @@
+# Ghostty profile: mcp-forge
+# Workload: tarn — MCP server dev in Rust/Docker
+# Inherits base config, overrides colors only
+config-file = ~/.config/ghostty/config
+
+background = "#1a0e00"
+foreground = "#ffd0a0"
+cursor-color = "#fab387"
+selection-background = "#3a2000"
+selection-foreground = "#ffd0a0"
+
+# Rust orange palette
+palette = 0=#1a0e00
+palette = 1=#f7768e
+palette = 2=#9ece6a
+palette = 3=#fab387
+palette = 4=#7aa2f7
+palette = 5=#bb9af7
+palette = 6=#7dcfff
+palette = 7=#ffd0a0
+palette = 8=#3a2000
+palette = 9=#f7768e
+palette = 10=#9ece6a
+palette = 11=#fab387
+palette = 12=#7aa2f7
+palette = 13=#bb9af7
+palette = 14=#7dcfff
+palette = 15=#ffd0a0

--- a/ghostty-profiles/otel.conf
+++ b/ghostty-profiles/otel.conf
@@ -1,0 +1,28 @@
+# Ghostty profile: otel
+# Workload: ralph-wiggum — OTEL traces, Jaeger, observability
+# Inherits base config, overrides colors only
+config-file = ~/.config/ghostty/config
+
+background = "#000000"
+foreground = "#00ff41"
+cursor-color = "#00ff41"
+selection-background = "#003300"
+selection-foreground = "#00ff41"
+
+# Matrix green / radar palette
+palette = 0=#000000
+palette = 1=#ff4444
+palette = 2=#00ff41
+palette = 3=#aaff00
+palette = 4=#00aaff
+palette = 5=#aa00ff
+palette = 6=#00ffaa
+palette = 7=#00cc33
+palette = 8=#003300
+palette = 9=#ff4444
+palette = 10=#00ff41
+palette = 11=#aaff00
+palette = 12=#00aaff
+palette = 13=#aa00ff
+palette = 14=#00ffaa
+palette = 15=#00ff41

--- a/ghostty-profiles/ssh-rocm.conf
+++ b/ghostty-profiles/ssh-rocm.conf
@@ -1,0 +1,29 @@
+# Ghostty profile: ssh-rocm
+# Workload: kade — SSH into ROCm-AIBOX (192.168.4.53), bare-metal Ubuntu/ROCm
+# Red accent: you always know you're remote
+# Inherits base config, overrides colors only
+config-file = ~/.config/ghostty/config
+
+background = "#1a0000"
+foreground = "#ffb3b3"
+cursor-color = "#f7768e"
+selection-background = "#3a0000"
+selection-foreground = "#ffb3b3"
+
+# Red/danger palette
+palette = 0=#1a0000
+palette = 1=#f7768e
+palette = 2=#9ece6a
+palette = 3=#e0af68
+palette = 4=#7aa2f7
+palette = 5=#bb9af7
+palette = 6=#7dcfff
+palette = 7=#ffb3b3
+palette = 8=#3a0000
+palette = 9=#ff0000
+palette = 10=#9ece6a
+palette = 11=#e0af68
+palette = 12=#7aa2f7
+palette = 13=#bb9af7
+palette = 14=#7dcfff
+palette = 15=#ffb3b3

--- a/install-haunting-terminal.sh
+++ b/install-haunting-terminal.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # install-haunting-terminal.sh
-# Adds Ghostty, btm, and zellij to an existing setup (see macOS-dev-setup.md).
+# Adds Ghostty, bottom, and zellij to an existing setup (see macOS-dev-setup.md).
 # Run from the repo root after cloning.
 set -euo pipefail
 
@@ -8,12 +8,17 @@ REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # --- Install new tools ---
 brew install --cask ghostty
-brew install btm zellij
+brew install bottom zellij  # 'bottom' provides the btm binary
 
-# --- Ghostty config ---
+# --- Ghostty base config ---
 mkdir -p ~/.config/ghostty
 cp "$REPO_DIR/ghostty-config" ~/.config/ghostty/config
-echo "Ghostty config installed."
+echo "Ghostty base config installed."
+
+# --- Ghostty workload profiles ---
+mkdir -p ~/.config/ghostty/profiles
+cp "$REPO_DIR/ghostty-profiles/"*.conf ~/.config/ghostty/profiles/
+echo "Ghostty workload profiles installed: inference, aws, otel, ssh-rocm, chrome-ext, mcp-forge"
 
 # --- Starship config ---
 mkdir -p ~/.config
@@ -31,3 +36,4 @@ else
 fi
 
 echo "Done. Open Ghostty and run: source ~/.zshrc"
+echo "Workload aliases: gt-inference | gt-aws | gt-otel | gt-rocm | gt-ext | gt-forge"

--- a/zshrc-copy
+++ b/zshrc-copy
@@ -81,8 +81,25 @@ alias ll="eza -l --group-directories-first --icons"  # long listing
 alias la="eza -la --group-directories-first --icons" # show hidden files
 alias gs="git status -sb"                             # short git status
 alias cat="bat --style=plain --paging=never"          # syntax-highlighted 'cat'
-alias top="btm"                                       # graphical system monitor
+alias top="btm"                                       # graphical system monitor (brew install bottom)
 alias mux="zellij"                                    # terminal multiplexer
+
+# --- Ghostty workload profiles ---
+# Open a new Ghostty window tuned for each haunting workload.
+# Usage: gt-inference, gt-aws, gt-otel, gt-rocm, gt-ext, gt-forge
+_GT="/Applications/Ghostty.app/Contents/MacOS/ghostty"
+_GP="$HOME/.config/ghostty/profiles"
+alias gt-inference="$_GT --config-file=$_GP/inference.conf"
+alias gt-aws="$_GT --config-file=$_GP/aws.conf"
+alias gt-otel="$_GT --config-file=$_GP/otel.conf"
+alias gt-rocm="$_GT --config-file=$_GP/ssh-rocm.conf"
+alias gt-ext="$_GT --config-file=$_GP/chrome-ext.conf"
+alias gt-forge="$_GT --config-file=$_GP/mcp-forge.conf"
+
+# SSH into ROCm-AIBOX in a dedicated red-accented window
+gt-ssh-rocm() {
+  "$_GT" --config-file="$_GP/ssh-rocm.conf" --command="ssh haunt-rocm $*"
+}
 
 # --- Editor preference ---
 # These tell tools (like git) which editor to use when one is needed.


### PR DESCRIPTION
## Workload profiles\n\nEach profile maps to a haunting agent family. Open the right window for the right work — the color tells you where you are.\n\n| Alias | Profile | Workload | Color |\n|---|---|---|---|\n| `gt-inference` | inference.conf | myrren — Ollama, Qdrant, local models | deep violet |\n| `gt-aws` | aws.conf | stratia — AWS, Bedrock, CDK | amber/orange |\n| `gt-otel` | otel.conf | ralph-wiggum — OTEL traces, Jaeger | matrix green |\n| `gt-rocm` | ssh-rocm.conf | kade — SSH into ROCm-AIBOX (192.168.4.53) | red (danger) |\n| `gt-ext` | chrome-ext.conf | ellow — Chrome MV3, Puppeteer, Jest | teal/cyan |\n| `gt-forge` | mcp-forge.conf | tarn — MCP servers in Rust/Docker | rust orange |\n\nEach profile inherits the base Ghostty config (font, opacity, padding) and overrides colors only.\n\n## Also fixes\n\n- `btm` formula name was wrong — corrected to `bottom` (which provides the `btm` binary)\n- `gt-ssh-rocm` shell function opens a red-accented window and SSHes into `haunt-rocm` in one command\n\n## Deploy\n\n```sh\nbash install-haunting-terminal.sh\nsource ~/.zshrc\n```"