### PR TITLE
security: scrub lan ip and user@host recon leaks

### DIFF
--- a/ghostty-profiles/ssh-rocm.conf
+++ b/ghostty-profiles/ssh-rocm.conf
@@ -1,5 +1,5 @@
 # Ghostty profile: ssh-rocm
-# Workload: kade — SSH into ROCm-AIBOX (192.168.4.53), bare-metal Ubuntu/ROCm
+# Workload: kade — SSH into ROCm-AIBOX (<rocm-aibox-lan-ip>), bare-metal Ubuntu/ROCm
 # Red accent: you always know you're remote
 # Inherits base config, overrides colors only
 config-file = ~/.config/ghostty/config

--- a/terminal-profiles/README.md
+++ b/terminal-profiles/README.md
@@ -48,7 +48,7 @@ A `ssh()` function wraps the real ssh command. When connecting to `rocm-aibox`:
 cp terminal-profiles/starship-mac-mini-warm.toml ~/.config/starship.toml
 
 # AIBox (via SSH)
-scp terminal-profiles/starship-aibox-cool.toml bryanchasko@rocm-aibox.local:~/.config/starship.toml
+scp terminal-profiles/starship-aibox-cool.toml user@rocm-aibox.local:~/.config/starship.toml
 ```
 
 ## Manual step: create ~/.secrets


### PR DESCRIPTION
## summary

public repo recon audit 2026-04-10 flagged two leaks via heraldstack-infra gitleaks ruleset.

- `ghostty-profiles/ssh-rocm.conf` line 2: internal LAN IP `192.168.4.53` → `<rocm-aibox-lan-ip>`
- `terminal-profiles/README.md` line 51: `bryanchasko@rocm-aibox.local` → `user@rocm-aibox.local`

both leaks expose internal network topology and operator identity in a public repo. scope is these two files only — no history rewrite required since the content is in comments and doc examples, not operational config.

## verification

`grep -rE '192\.168\.4\.|bryanchasko@' .` returns no working-tree matches post-patch.